### PR TITLE
Test dockercompose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,8 @@ FROM node:16-alpine as dev
 # Prepare app directory
 WORKDIR /home/node/app
 
-# Set up local user
-RUN chown -R node:node /home/node/app
-USER node
-
 # Copy files from builder image
-COPY --from=builder --chown=node:node /usr/src/app .
+COPY --from=builder /usr/src/app .
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=builder /usr/src/app .
 RUN npm prune --production
 
 
-FROM --platform=amd64 node:16-alpine as dev
+FROM node:16-alpine as dev
 
 # Prepare app directory
 WORKDIR /home/node/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,25 @@
-FROM node:16-alpine AS builder
+FROM --platform=amd64 node:16-alpine AS dev
 
 # Prepare app directory
-WORKDIR /usr/src/app
-COPY package*.json ./
+WORKDIR /home/node/app
+COPY . .
+
+# Set up local user
+RUN chown -R node:node /home/node/app
+USER node
 
 # Install dependencies
 RUN npm install glob rimraf
 RUN npm install
 
-COPY . .
+FROM node:16-alpine AS builder 
+
+# Prepare app directory
+WORKDIR /usr/src/app
+
+# Set up local user
+# Copy files from dev image
+COPY --from=dev /home/node/app .
 
 # Build app
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@
 6. Go to http://localhost:3000/explorer-next to get an overview of available endpoints and database schemas.
 7. To be able to run the e2e tests with the same setup as in the Github actions you will need to run `npm run  prepare:local` and after that run `npm run start:dev`. This will start all needed containers and copy some configuration to the right place.
 
+## Develop in a container using the docker-compose.dev file
+
+1. `git clone https://github.com/SciCatProject/scicat-backend-next.git`
+2. docker-compose -f docker-compose.dev.yaml up -d
+3. *Optional* Mount *functionalAccounts.json* file to a volume in the container. If not set up, the functional accounts in [functionalAccounts.json.example](/functionalAccounts.json.example) will be created automatically.
+4. *Optional* change the container env variables
+5. Attach to the container
+6. `npm run start:dev`
+7. Go to http://localhost:3000/explorer-next to get an overview of available endpoints and database schemas.
+
 ## Test the app
 
 1. **Running the unit tests:** `npm run test`

--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@
 2. docker-compose -f docker-compose.dev.yaml up -d
 3. *Optional* Mount *functionalAccounts.json* file to a volume in the container. If not set up, the functional accounts in [functionalAccounts.json.example](/functionalAccounts.json.example) will be created automatically.
 4. *Optional* change the container env variables
-5. Attach to the container
-6. `npm run start:dev`
-7. Go to http://localhost:3000/explorer-next to get an overview of available endpoints and database schemas.
+5. Go to http://localhost:3000/explorer-next to get an overview of available endpoints and database schemas.
 
 ## Test the app
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,34 @@
+services:
+  mongodb:
+    image: bitnami/mongodb:4.2
+    volumes:
+      - mongodb_data:/bitnami
+  backend:
+    build: 
+      context: .
+      target: dev
+    depends_on:
+      - mongodb
+    ports:
+      - 3000:3000
+    volumes:
+      - .:/home/node/app
+      - /home/node/app/node_modules
+    environment:
+      MONGODB_URI: mongodb://mongodb:27017/scicat
+      EXPRESS_SESSION_SECRET: a_scicat_secret
+      JWT_SECRET: a_scicat_secret
+      PORT: 3000
+      HTTP_MAX_REDIRECTS: 5
+      HTTP_TIMEOUT: 5000
+      JWT_EXPIRES_IN: 3600
+      SITE: SAMPLE-SITE
+      PID_PREFIX: PID.SAMPLE.PREFIX
+      DOI_PREFIX: DOI.SAMPLE.PREFIX
+      METADATA_KEYS_RETURN_LIMIT: 100
+      METADATA_PARENT_INSTANCES_RETURN_LIMIT: 100
+    command: /bin/sh -c "while true; do sleep 600; done"
+
+volumes:
+  mongodb_data:
+    driver: local

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -27,7 +27,6 @@ services:
       DOI_PREFIX: DOI.SAMPLE.PREFIX
       METADATA_KEYS_RETURN_LIMIT: 100
       METADATA_PARENT_INSTANCES_RETURN_LIMIT: 100
-    command: /bin/sh -c "while true; do sleep 600; done"
 
 volumes:
   mongodb_data:


### PR DESCRIPTION
## Description

Set up docker compose that will allow spin up of dev backend-next

## Motivation

Makes development easier. This can be run on mac and linux

## Fixes:

* Docker build works for both dev and prod
* Dev backend-next is spun up by the docker compose. No manual intervention required

## Changes:

* Multi-stage and multi route docker build
* Removed instruction to attach and run commands in docker container as not necessary

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [x] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
